### PR TITLE
Feature: geo:json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/phoops/ngsiv2
 
 go 1.13
+
+require github.com/paulmach/go.geojson v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/phoops/ngsiv2
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/paulmach/go.geojson v1.4.0 h1:5x5moCkCtDo5x8af62P9IOAYGQcYHtxz2QJ3x1DoCgY=
+github.com/paulmach/go.geojson v1.4.0/go.mod h1:YaKx1hKpWF+T2oj2lFJPsW/t1Q5e1jQI61eoQSTwpIs=

--- a/model/model.go
+++ b/model/model.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	geojson "github.com/paulmach/go.geojson"
 )
 
 // Entity is a context entity, i.e. a thing in the NGSI model.
@@ -300,7 +302,11 @@ func (e *Entity) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	_ = json.Unmarshal(b, &(t_.Attributes))
+	var jsonValues map[string]json.RawMessage
+
+	if err := json.Unmarshal(b, &jsonValues); err != nil {
+		return err
+	}
 	/*if err := json.Unmarshal(b, &(t_.Attributes)); err != nil {
 		return err
 	}*/
@@ -310,14 +316,27 @@ func (e *Entity) UnmarshalJSON(b []byte) error {
 		field := typ.Field(i)
 		jsonTag := strings.Split(field.Tag.Get("json"), ",")[0]
 		if jsonTag != "" && jsonTag != "-" {
-			delete(t_.Attributes, jsonTag)
+			delete(jsonValues, jsonTag)
 		}
 	}
 
-	for _, a := range t_.Attributes {
+	t_.Attributes = make(map[string]*Attribute, len(jsonValues))
+	for attr, aJson := range jsonValues {
+		if !IsValidFieldSyntax(attr) {
+			fmt.Printf("[Warning] Attribute %v has wrong field syntax\n", attr)
+		}
+		var a Attribute
+
+		if err := json.Unmarshal(aJson, &a); err != nil {
+			return err
+		}
 		switch a.Type {
 		case DateTimeType:
-			if v, err := time.Parse(time.RFC3339, a.Value.(string)); err == nil {
+			val, ok := a.Value.(string)
+			if !ok {
+				return fmt.Errorf("Invalid DateTimeType value: '%v'", a.Value)
+			}
+			if v, err := time.Parse(time.RFC3339, val); err == nil {
 				a.Value = v
 			}
 		case GeoPointType:
@@ -329,7 +348,22 @@ func (e *Entity) UnmarshalJSON(b []byte) error {
 			if err := g.UnmarshalJSON([]byte(val)); err == nil {
 				a.Value = g
 			}
+		case GeoJSONType:
+			var ma map[string]json.RawMessage
+			if err := json.Unmarshal(aJson, &ma); err != nil {
+				return err
+			}
+			gJSON, ok := ma["value"]
+			if !ok {
+				return fmt.Errorf("Invalid geo:json value: '%v'", a)
+			}
+			g := new(geojson.Geometry)
+			if err := g.UnmarshalJSON(gJSON); err != nil {
+				return err
+			}
+			a.Value = g
 		}
+		t_.Attributes[attr] = &a
 	}
 
 	*e = Entity(t_)
@@ -554,6 +588,19 @@ func (e *Entity) SetAttributeAsGeoPoint(name string, value *GeoPoint) error {
 	return nil
 }
 
+func (e *Entity) SetAttributeAsGeoJSON(name string, value *geojson.Geometry) error {
+	if err := validateAttributeName(name); err != nil {
+		return err
+	}
+	e.Attributes[name] = &Attribute{
+		typeValue: typeValue{
+			Type:  GeoJSONType,
+			Value: value,
+		},
+	}
+	return nil
+}
+
 func (a *Attribute) GetAsString() (string, error) {
 	if a.Type != StringType {
 		return "", fmt.Errorf("Attribute is not String, but %s", a.Type)
@@ -612,6 +659,19 @@ func (a *Attribute) GetAsGeoPoint() (*GeoPoint, error) {
 	} else {
 		return g, nil
 	}
+}
+
+func (a *Attribute) GetAsGeoJSON() (*geojson.Geometry, error) {
+	if a.Type != GeoJSONType {
+		return nil, fmt.Errorf("Attribute is not geo:json, but '%s'", a.Type)
+	}
+	fmt.Println("type:", reflect.TypeOf(a.Value))
+	fmt.Println(a.Value)
+	g, ok := a.Value.(*geojson.Geometry)
+	if !ok {
+		return nil, fmt.Errorf("Attribute with geo:json type does not contain geo:json value")
+	}
+	return g, nil
 }
 
 func (e *Entity) GetAttributeAsString(attributeName string) (string, error) {
@@ -684,6 +744,14 @@ func (e *Entity) GetAttributeAsGeoPoint(attributeName string) (*GeoPoint, error)
 	} else {
 		return a.GetAsGeoPoint()
 	}
+}
+
+func (e *Entity) GetAttributeAsGeoJSON(attributeName string) (*geojson.Geometry, error) {
+	a, err := e.GetAttribute(attributeName)
+	if err != nil {
+		return new(geojson.Geometry), err
+	}
+	return a.GetAsGeoJSON()
 }
 
 func NewBatchUpdate(action ActionType) *BatchUpdate {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -216,6 +216,33 @@ func TestEntityUnmarshal(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error unmarshaling invalid geo:point")
 	}
+
+	geoJSON := `
+	{
+		"id": "GeoJSON1",
+		"location": {
+			"type": "geo:json",
+			"value": {
+				"type": "Point",
+				"coordinates": [-4.754444444, 41.640833333]
+			}
+		},
+		"type": "WeatherObserved"
+	}
+	`
+
+	geoJSONEntity := &model.Entity{}
+	if err := json.Unmarshal([]byte(geoJSON), geoJSONEntity); err != nil {
+		t.Fatalf("Error unmarshaling entity: %v", err)
+	}
+
+	if geoLocation, err := geoJSONEntity.GetAttributeAsGeoJSON("location"); err != nil {
+		t.Fatalf("Error GetAttributeAsGeoJSON 'location': %v", err)
+	} else {
+		if !geoLocation.IsPoint() {
+			t.Fatalf("Expected value to be a Point got %v", err)
+		}
+	}
 }
 
 func TestEntityMarshal(t *testing.T) {


### PR DESCRIPTION
I added support for geo:json types. It uses https://github.com/paulmach/go.geojson for the Structs, but probably could be swapped out with https://github.com/tidwall/geojson.

I had to change the way the Unmarshal was being done. I map the Attributes to a "map[string]json.RawMessage" and then process them. I did that because I could not find out why the "Value" Property inside a "geo:json" was being "casted" to "map[string]interface". 

I added a happy case test, but we probably need also a "fubar" case. 