### PR TITLE
Add support for structured value type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/phoops/ngsiv2
 
 go 1.13
 
-require github.com/paulmach/go.geojson v1.4.0
+require (
+	github.com/mitchellh/mapstructure v1.4.2
+	github.com/paulmach/go.geojson v1.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/mitchellh/mapstructure v1.4.2 h1:6h7AQ0yhTcIsmFmnAwQls75jp2Gzs4iB8W7pjMO+rqo=
+github.com/mitchellh/mapstructure v1.4.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/paulmach/go.geojson v1.4.0 h1:5x5moCkCtDo5x8af62P9IOAYGQcYHtxz2QJ3x1DoCgY=
 github.com/paulmach/go.geojson v1.4.0/go.mod h1:YaKx1hKpWF+T2oj2lFJPsW/t1Q5e1jQI61eoQSTwpIs=


### PR DESCRIPTION
With this PR we add basic support for `StructuredValue` attribute type and generic decoding of these attributes to map or structures via [mapstructure](github.com/mitchellh/mapstructure) library.